### PR TITLE
Checklog find log package and fmt.Print* api

### DIFF
--- a/checklog/checklog.go
+++ b/checklog/checklog.go
@@ -60,7 +60,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			if node.Name != nil {
 				packagePath2Name[strings.Trim(node.Path.Value, `"`)] = node.Name.String()
 			}
-			for _, spec := range blockList {
+			for _, spec := range blockPackageList {
 				path := node.Path.Value
 				if path == spec.MatchPath {
 					if spec.PassTestFile && isTestFile(pass, n) {
@@ -104,7 +104,7 @@ type blockSpec struct {
 	PassTestFile bool
 }
 
-var blockList = []blockSpec{
+var blockPackageList = []blockSpec{
 	{
 		MatchPath:    "log",
 		UseInstead:   "github.com/matrixorigin/matrixone/pkg/logutil",
@@ -168,15 +168,6 @@ func isWhiteListed(whiteList []approved, typeName string, functionName string) (
 		}
 	}
 	return false
-}
-
-func isCallingBuiltInRecover(expr ast.Expr) bool {
-	if _, ok := expr.(*ast.SelectorExpr); ok {
-		return false
-	}
-	id, ok := expr.(*ast.Ident)
-
-	return ok && id.Name == "recover"
 }
 
 // getSelector parse X ast.Expr in ast.SelectorExpr.

--- a/checklog/checklog.go
+++ b/checklog/checklog.go
@@ -1,0 +1,258 @@
+// Copyright 2021 - 2022 Matrix Origin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checklog
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/ast/inspector"
+	"regexp"
+	"strings"
+)
+
+const doc = "Tool to check the usage of log.Print() or fmt.Print() to ensure it is only used by pre-approved methods and functions. See https://....md for more details."
+
+var Analyzer = &analysis.Analyzer{
+	Name:     "checklog",
+	Doc:      doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	// get the inspector. This will not panic because inspect.Analyzer is part
+	// of `Requires`. go/analysis will populate the `pass.ResultOf` map with
+	// the prerequisite analyzers.
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	// the inspector has a `filter` feature that enables type-based filtering
+	// The anonymous function will be only called for the ast nodes whose type
+	// matches an element in the filter
+	nodeFilter := []ast.Node{
+		(*ast.ImportSpec)(nil),
+		(*ast.CallExpr)(nil),
+	}
+	packagePath2Name := make(map[string]string)
+	// this is basically the same as ast.Inspect(), only we don't return a
+	// boolean anymore as it'll visit all the nodes based on the filter.
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+
+		switch node := n.(type) {
+		case *ast.ImportSpec:
+			if node.Name != nil {
+				packagePath2Name[strings.Trim(node.Path.Value, `"`)] = node.Name.String()
+			}
+			for _, spec := range blockList {
+				path := node.Path.Value
+				if path == spec.MatchPath {
+					if spec.PassTestFile && isTestFile(pass, n) {
+						continue
+					}
+					message := fmt.Sprintf("do not use package %s", spec.MatchPath)
+					if spec.UseInstead != "" {
+						message += fmt.Sprintf(", use %s instead", spec.UseInstead)
+					}
+					pass.Reportf(n.Pos(), message)
+				}
+			}
+		case *ast.CallExpr:
+			for _, spec := range blockFuncList {
+				function := getCallingFunction(node.Fun)
+				if function == spec.getFunction(packagePath2Name) && !isTestFile(pass, n) {
+					typeName, funcName, ok := getMethodDetails(pass, n)
+					if !ok {
+						typeName, funcName, ok = getFunctionDetails(pass, n)
+						if !ok {
+							panic("failed to identify method/function details")
+						}
+					}
+					if isWhiteListed(whiteList4Log, typeName, funcName) {
+						continue
+					}
+					pass.Reportf(n.Pos(), "unsafe log %s: in %s.%s()", function, typeName, funcName)
+				}
+			}
+		default:
+			return
+		}
+	})
+	return nil, nil
+}
+
+type blockSpec struct {
+	MatchModule  string
+	MatchPath    string
+	UseInstead   string
+	PassTestFile bool
+}
+
+var blockList = []blockSpec{
+	{
+		MatchPath:    "log",
+		UseInstead:   "github.com/matrixorigin/matrixone/pkg/logutil",
+		PassTestFile: true,
+	},
+}
+
+type functionSpec struct {
+	Module   string // like: fmt
+	Function string // like: Printf
+}
+
+func (spec functionSpec) getFunction(pkgAlias map[string]string) string {
+	if len(spec.Module) == 0 {
+		return spec.Function
+	} else {
+		var moduleSelector = spec.Module
+		if val, ok := pkgAlias[spec.Module]; ok {
+			moduleSelector = val
+		}
+		return moduleSelector + "." + spec.Function
+	}
+}
+
+var blockFuncList = []functionSpec{
+	{Module: "fmt", Function: "Print"},
+	{Module: "fmt", Function: "Printf"},
+	{Module: "fmt", Function: "Println"},
+	{Module: "fmt", Function: "Fprint"},
+	{Module: "fmt", Function: "Fprintf"},
+	{Module: "fmt", Function: "Fprintln"},
+}
+
+type approved struct {
+	receiverTypeName string
+	functionName     string
+}
+
+var whiteList4Log = []approved{
+	{`github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc`, `*`},
+	{`github.com/matrixorigin/matrixone/cmd/mo-service`, `maybePrintVersion`},
+	{`.*/example`, `*`},
+	{`.*/example\..*`, `*`},
+	{`github.com/matrixorigin/matrixone/pkg/sql/plan/function/builtin/binary`, `makeDateFormat`},
+	{`github.com/matrixorigin/matrixone/pkg/txn/storage/memorystorage/memtable.PhysicalRow[K, V]`, `dump`},
+}
+
+func isWhiteListed(whiteList []approved, typeName string, functionName string) (match bool) {
+	for _, rec := range whiteList {
+		if rec.receiverTypeName == typeName && (rec.functionName == functionName || rec.functionName == "*") {
+			return true
+		}
+		valuesRe := regexp.MustCompile(rec.receiverTypeName)
+		if len(valuesRe.FindAllString(typeName, -1)) > 0 && (rec.functionName == functionName || rec.functionName == "*") {
+			return true
+		}
+	}
+	return false
+}
+
+func isCallingBuiltInRecover(expr ast.Expr) bool {
+	if _, ok := expr.(*ast.SelectorExpr); ok {
+		return false
+	}
+	id, ok := expr.(*ast.Ident)
+
+	return ok && id.Name == "recover"
+}
+
+// getSelector parse X ast.Expr in ast.SelectorExpr.
+// like:         a.Func1()
+// - or:       a.b.Func2()
+// - or:  a.arr[0].Func3()
+// -------------- | -------
+// -            X | Sel
+func getSelector(xExpr ast.Expr) (selector string) {
+	if id, ok := xExpr.(*ast.Ident); ok {
+		selector = id.Name
+	} else if se, ok := xExpr.(*ast.SelectorExpr); ok {
+		selector = getSelector(se.X) + "." + se.Sel.Name
+	} else if _, ok := xExpr.(*ast.IndexExpr); ok {
+		selector = "" // not implement
+	}
+	return selector
+}
+
+func getCallingFunction(expr ast.Expr) (function string) {
+	if s, ok := expr.(*ast.SelectorExpr); ok {
+		var selector = getSelector(s.X)
+		var currentFunc = s.Sel.Name
+		if len(selector) > 0 {
+			currentFunc = selector + "." + currentFunc
+		}
+		function = currentFunc
+	} else if id, ok := expr.(*ast.Ident); ok {
+		function = id.Name
+	}
+	return function
+}
+
+func isTestFile(pass *analysis.Pass, node ast.Node) bool {
+	var file *ast.File
+	for _, f := range pass.Files {
+		if f.Pos() <= node.Pos() && node.Pos() < f.End() {
+			file = f
+			break
+		}
+	}
+	if file == nil {
+		panic("failed to locate the file")
+	}
+	tokenFile := pass.Fset.File(file.Pos())
+	if tokenFile == nil {
+		panic("token file is nil")
+	}
+
+	return strings.HasSuffix(tokenFile.Name(), "_test.go")
+}
+
+func getMethodDetails(pass *analysis.Pass, node ast.Node) (string, string, bool) {
+	for _, file := range pass.Files {
+		path, _ := astutil.PathEnclosingInterval(file, node.Pos(), node.Pos())
+		if len(path) == 0 {
+			continue
+		}
+		for _, cp := range path {
+			if fd, ok := cp.(*ast.FuncDecl); ok && fd.Recv != nil {
+				recvExp := fd.Recv.List[0].Type
+				if p, ok := pass.TypesInfo.Types[recvExp].Type.(*types.Pointer); ok {
+					return p.Elem().String(), fd.Name.Name, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+func getFunctionDetails(pass *analysis.Pass, node ast.Node) (string, string, bool) {
+	for _, file := range pass.Files {
+		path, _ := astutil.PathEnclosingInterval(file, node.Pos(), node.Pos())
+		if len(path) == 0 {
+			continue
+		}
+		for _, cp := range path {
+			if fd, ok := cp.(*ast.FuncDecl); ok && fd.Recv == nil {
+				p := pass.TypesInfo.Defs[fd.Name].Pkg().Path()
+				return p, fd.Name.Name, true
+			}
+		}
+	}
+
+	return "", "", false
+}

--- a/checklog/checklog_test.go
+++ b/checklog/checklog_test.go
@@ -16,7 +16,6 @@ func Test_isWhiteListed(t *testing.T) {
 		{
 			name: "normal",
 			args: args{
-
 				//getFunction type, func: 'github.com/matrixorigin/matrixone/pkg/sql/parsers/example', 'main'
 				//pkg/sql/parsers/example/eg_mysql.go:33:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/example.main()
 				// -----

--- a/checklog/checklog_test.go
+++ b/checklog/checklog_test.go
@@ -1,0 +1,48 @@
+package checklog
+
+import "testing"
+
+func Test_isWhiteListed(t *testing.T) {
+	type args struct {
+		whiteList    []approved
+		typeName     string
+		functionName string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantMatch bool
+	}{
+		{
+			name: "normal",
+			args: args{
+
+				//getFunction type, func: 'github.com/matrixorigin/matrixone/pkg/sql/parsers/example', 'main'
+				//pkg/sql/parsers/example/eg_mysql.go:33:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/example.main()
+				// -----
+				// # github.com/matrixorigin/matrixone/pkg/util/trace/example
+				//getMethod type, func: 'github.com/matrixorigin/matrixone/pkg/util/trace/example.dummyStringWriter', 'WriteString'
+				whiteList:    whiteList4Log,
+				typeName:     "github.com/matrixorigin/matrixone/pkg/sql/parsers/example",
+				functionName: "main",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "normal",
+			args: args{
+				whiteList:    whiteList4Log,
+				typeName:     "github.com/matrixorigin/matrixone/pkg/util/trace/example.dummyStringWriter",
+				functionName: "WriteString",
+			},
+			wantMatch: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotMatch := isWhiteListed(tt.args.whiteList, tt.args.typeName, tt.args.functionName); gotMatch != tt.wantMatch {
+				t.Errorf("isWhiteListed() = %v, want %v", gotMatch, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/checklog/checklog_test.go
+++ b/checklog/checklog_test.go
@@ -21,7 +21,7 @@ func Test_isWhiteListed(t *testing.T) {
 				// -----
 				// # github.com/matrixorigin/matrixone/pkg/util/trace/example
 				//getMethod type, func: 'github.com/matrixorigin/matrixone/pkg/util/trace/example.dummyStringWriter', 'WriteString'
-				whiteList:    whiteList4Log,
+				whiteList:    whiteList4fmt,
 				typeName:     "github.com/matrixorigin/matrixone/pkg/sql/parsers/example",
 				functionName: "main",
 			},
@@ -30,7 +30,7 @@ func Test_isWhiteListed(t *testing.T) {
 		{
 			name: "normal",
 			args: args{
-				whiteList:    whiteList4Log,
+				whiteList:    whiteList4fmt,
 				typeName:     "github.com/matrixorigin/matrixone/pkg/util/trace/example.dummyStringWriter",
 				functionName: "WriteString",
 			},

--- a/cmd/molint/main.go
+++ b/cmd/molint/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/matrixorigin/linter/checklog"
 	"github.com/matrixorigin/linter/checkrecover"
 	"github.com/matrixorigin/linter/pkgblocklist"
 
@@ -25,5 +26,6 @@ func main() {
 	unitchecker.Main(
 		checkrecover.Analyzer,
 		pkgblocklist.Analyzer,
+		checklog.Analyzer,
 	)
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] API-change
- [ ] BUG
- [ ] Improvement
- [ ] Documentation
- [x] Feature
- [ ] Test and CI
- [ ] Code Refactoring

## Which issue(s) this PR fixes:

issue #8 

## What this PR does / why we need it:
Check usage of `log` package, or `fmt.Print*` api.
Ensure that logs are controlled by `github.com/matrixorigin/matrixone/pkg/logutil`

### white list (following result ignored)

```
# github.com/matrixorigin/matrixone/pkg/sql/parsers/example
pkg/sql/parsers/example/eg_mysql.go:30:3: unsafe log fmt.Println: in github.com/matrixorigin/matrixone/pkg/sql/parsers/example.main()
pkg/sql/parsers/example/eg_mysql.go:32:2: unsafe log fmt.Println: in github.com/matrixorigin/matrixone/pkg/sql/parsers/example.main()
pkg/sql/parsers/example/eg_mysql.go:33:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/example.main()
# github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql
pkg/sql/parsers/dialect/postgresql/yaccpar:155: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yylex1()
pkg/sql/parsers/dialect/postgresql/yaccpar:194: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/postgresql/yaccpar:264: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/postgresql/yaccpar:265: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/postgresql/yaccpar:284: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/postgresql/yaccpar:293: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/postgresql/yaccpar:306: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/postgresql.yyParserImpl.Parse()
# github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc
pkg/sql/parsers/goyacc/goyacc.go:883:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:890:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:910:6: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:919:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:936:6: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:949:5: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:954:5: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:959:5: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:969:6: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:988:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:998:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:1017:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:1024:3: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.gettok()
pkg/sql/parsers/goyacc/goyacc.go:1673:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.cpres()
pkg/sql/parsers/goyacc/goyacc.go:1676:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.cpres()
pkg/sql/parsers/goyacc/goyacc.go:2698:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.hideprod()
pkg/sql/parsers/goyacc/goyacc.go:2704:3: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.hideprod()
pkg/sql/parsers/goyacc/goyacc.go:2992:5: unsafe log fmt.Print: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.others()
pkg/sql/parsers/goyacc/goyacc.go:2993:5: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.others()
pkg/sql/parsers/goyacc/goyacc.go:3016:5: unsafe log fmt.Print: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.others()
pkg/sql/parsers/goyacc/goyacc.go:3017:5: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.others()
pkg/sql/parsers/goyacc/goyacc.go:3190:3: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.summary()
pkg/sql/parsers/goyacc/goyacc.go:3192:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.summary()
pkg/sql/parsers/goyacc/goyacc.go:3195:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.summary()
pkg/sql/parsers/goyacc/goyacc.go:3198:4: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.summary()
pkg/sql/parsers/goyacc/goyacc.go:3200:3: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/goyacc.summary()
# github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql
pkg/sql/parsers/dialect/mysql/yaccpar:155: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yylex1()
pkg/sql/parsers/dialect/mysql/yaccpar:194: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/mysql/yaccpar:264: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/mysql/yaccpar:265: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/mysql/yaccpar:284: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/mysql/yaccpar:293: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
pkg/sql/parsers/dialect/mysql/yaccpar:306: unsafe log __yyfmt__.Printf: in github.com/matrixorigin/matrixone/pkg/sql/parsers/dialect/mysql.yyParserImpl.Parse()
# github.com/matrixorigin/matrixone/cmd/mo-service
cmd/mo-service/version.go:40:2: unsafe log fmt.Println: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
cmd/mo-service/version.go:41:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
cmd/mo-service/version.go:42:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
cmd/mo-service/version.go:43:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
cmd/mo-service/version.go:44:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
cmd/mo-service/version.go:45:2: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/cmd/mo-service.maybePrintVersion()
# github.com/matrixorigin/matrixone/pkg/util/trace/example
pkg/util/trace/example/main.go:50:9: unsafe log fmt.Printf: in github.com/matrixorigin/matrixone/pkg/util/trace/example.dummyStringWriter.WriteString()
```

