### PR TITLE
add inspect recover whitelist

### DIFF
--- a/checkrecover/checkrecover.go
+++ b/checkrecover/checkrecover.go
@@ -62,6 +62,9 @@ var whiteList = []approved{
 
 	{"github.com/matrixorigin/matrixone/pkg/common/morpc.remoteBackend", "writeLoop"},
 	{"github.com/matrixorigin/matrixone/pkg/common/morpc.remoteBackend", "readLoop"},
+
+	// recover for inpsect dn
+	{"github.com/matrixorigin/matrixone/pkg/vm/engine/tae/rpc.Handle", "HandleInspectTN"},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {


### PR DESCRIPTION
mo-ctl inspect cmd is not expected to restart dn node.