### PR TITLE
fix ci sca

### DIFF
--- a/checkrecover/checkrecover.go
+++ b/checkrecover/checkrecover.go
@@ -55,6 +55,7 @@ var whiteList = []approved{
 	{"github.com/matrixorigin/matrixone/pkg/sql/compile", "CnServerMessageHandler"},
 
 	// https://github.com/matrixorigin/matrixone/issues/2764
+	{"github.com/matrixorigin/matrixone/pkg/frontend.MysqlCmdExecutor", "ExecRequest"},
 	{"github.com/matrixorigin/matrixone/pkg/frontend", "ExecRequest"},
 	{"github.com/matrixorigin/matrixone/pkg/frontend", "commitTxnFunc"},
 	{"github.com/matrixorigin/matrixone/pkg/frontend", "finishTxnFunc"},


### PR DESCRIPTION
错误删除了一条checkrecover 规则导致ci sca失败。

main旧代码，还需要这条规则。