### PR TITLE
change panic recover

### DIFF
--- a/checkrecover/checkrecover.go
+++ b/checkrecover/checkrecover.go
@@ -68,6 +68,7 @@ var whiteList = []approved{
 	{"github.com/matrixorigin/matrixone/pkg/frontend.Conn", "ReadOnePayload"},
 	{"github.com/matrixorigin/matrixone/pkg/frontend.Conn", "AllocNewBlock"},
 	{"github.com/matrixorigin/matrixone/pkg/frontend.Conn", "ExecuteFuncWithRecover"},
+	{"github.com/matrixorigin/matrixone/pkg/frontend", "ExecuteFuncWithRecover"},
 
 	// transaction state management
 	{"github.com/matrixorigin/matrixone/pkg/frontend.MysqlCmdExecutor", "executeStmt"},


### PR DESCRIPTION
之前，“ExecuteFuncWithRecover”的recover 的linter检查加错位置了。
当时用了绕过去的方式修改的。这个pr把这个问题改掉。再修改mo的代码。