### PR TITLE
checkrecover: ignore util/export.bufferHolder::getGenerateReq

### DIFF
--- a/checkrecover/checkrecover.go
+++ b/checkrecover/checkrecover.go
@@ -85,6 +85,9 @@ var whiteList = []approved{
 
 	// temporary recover to location issue #16007
 	{"github.com/matrixorigin/matrixone/pkg/pb/status.Session", "MarshalToSizedBuffer"},
+
+	// temporary recover to location issue #19755
+	{"github.com/matrixorigin/matrixone/pkg/util/export.bufferHolder", "getGenerateReq"},
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {


### PR DESCRIPTION
针对  https://github.com/matrixorigin/matrixone/issues/19755#issuecomment-2461696796
规避 panic 导致 mo crash, 后续持续分析。