### PR TITLE
checkrecover: ignore util/export.bufferHolder::Add

### DIFF
--- a/checkrecover/checkrecover.go
+++ b/checkrecover/checkrecover.go
@@ -89,6 +89,7 @@ var whiteList = []approved{
 	{"github.com/matrixorigin/matrixone/pkg/pb/status.Session", "MarshalToSizedBuffer"},
 
 	// temporary recover to location issue #19755
+	{"github.com/matrixorigin/matrixone/pkg/util/export.bufferHolder", "Add"},
 	{"github.com/matrixorigin/matrixone/pkg/util/export.bufferHolder", "getGenerateReq"},
 }
 


### PR DESCRIPTION
like https://github.com/matrixorigin/linter/pull/33
规避 panic 导致 mo crash, 后续持续分析